### PR TITLE
Increase flexibility

### DIFF
--- a/MCP3008/app/src/main/java/com/paultrebilcoxruiz/mcp3008/MCP3008.java
+++ b/MCP3008/app/src/main/java/com/paultrebilcoxruiz/mcp3008/MCP3008.java
@@ -52,20 +52,32 @@ import java.io.IOException;
 
 public class MCP3008 {
 
+    private final String csPin;
+    private final String clockPin;
+    private final String mosiPin;
+    private final String misoPin;
+
     private Gpio mCsPin;
     private Gpio mClockPin;
     private Gpio mMosiPin;
     private Gpio mMisoPin;
 
-    public MCP3008(String csPin, String clockPin, String mosiPin, String misoPin) throws IOException {
+    public MCP3008(String csPin, String clockPin, String mosiPin, String misoPin) {
+        this.csPin = csPin;
+        this.clockPin = clockPin;
+        this.mosiPin = mosiPin;
+        this.misoPin = misoPin;
+    }
+
+    public void register() throws IOException {
         PeripheralManagerService service = new PeripheralManagerService();
         mClockPin = service.openGpio(clockPin);
         mCsPin = service.openGpio(csPin);
         mMosiPin = service.openGpio(mosiPin);
         mMisoPin = service.openGpio(misoPin);
 
-        mCsPin.setDirection(Gpio.DIRECTION_OUT_INITIALLY_LOW);
         mClockPin.setDirection(Gpio.DIRECTION_OUT_INITIALLY_LOW);
+        mCsPin.setDirection(Gpio.DIRECTION_OUT_INITIALLY_LOW);
         mMosiPin.setDirection(Gpio.DIRECTION_OUT_INITIALLY_LOW);
         mMisoPin.setDirection(Gpio.DIRECTION_IN);
     }

--- a/MCP3008/app/src/main/java/com/paultrebilcoxruiz/mcp3008/MCP3008.java
+++ b/MCP3008/app/src/main/java/com/paultrebilcoxruiz/mcp3008/MCP3008.java
@@ -146,32 +146,32 @@ public class MCP3008 {
         if( mCsPin != null ) {
             try {
                 mCsPin.close();
-            } catch( IOException e ) {
-
+            } catch( IOException ignore ) {
+                // do nothing
             }
         }
 
         if( mClockPin != null ) {
             try {
                 mClockPin.close();
-            } catch( IOException e ) {
-
+            } catch( IOException ignore ) {
+               // do nothing
             }
         }
 
         if( mMisoPin != null ) {
             try {
                 mMisoPin.close();
-            } catch( IOException e ) {
-
+            } catch( IOException ignore ) {
+               // do nothing
             }
         }
 
         if( mMosiPin != null ) {
             try {
                 mMosiPin.close();
-            } catch( IOException e ) {
-
+            } catch( IOException ignore ) {
+               // do nothing
             }
         }
     }

--- a/MCP3008/app/src/main/java/com/paultrebilcoxruiz/mcp3008/MainActivity.java
+++ b/MCP3008/app/src/main/java/com/paultrebilcoxruiz/mcp3008/MainActivity.java
@@ -81,6 +81,7 @@ public class MainActivity extends Activity {
 
         try {
             mMCP3008 = new MCP3008("BCM12", "BCM21", "BCM16", "BCM20");
+            mMCP3008.register();
         } catch( IOException e ) {
             Log.e("MCP3008", "MCP initialization exception occurred: " + e.getMessage());
         }


### PR DESCRIPTION
Not doing work in the constructor allows you to create the class somewhere and use it somewhere else.

i.e. Dependency Injection or unit testing

It also makes the public api more obvious with a `register/unregister` pair